### PR TITLE
upgrade ref module for latest node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "coffee-script": "~1.7.1",
     "lodash": "~2.4.1",
-    "ref": "~0.1.3"
+    "ref": "~1.1.0"
   },
   "devDependencies": {
     "should": "~4.0.4",


### PR DESCRIPTION
Upgrade ref. Which make this module passing `npm install` in  node 4.0, I assuming it will works between 0.8~4.0. Since 1.1.0 of `ref` is using `nan` 2.

For cdef-messages~~~!!

@nguyenchr @rprieto 