### PR TITLE
Don't return anything on skip

### DIFF
--- a/src/clever-buffer-common.coffee
+++ b/src/clever-buffer-common.coffee
@@ -27,6 +27,7 @@ class CleverBuffer
 
   skip: (bytesToSkip) =>
     @offset += bytesToSkip
+    return
 
   skipTo: (offset) =>
     @offset = offset

--- a/test/clever-buffer-reader.spec.coffee
+++ b/test/clever-buffer-reader.spec.coffee
@@ -105,7 +105,8 @@ describe 'CleverBufferReader', ->
 
   it 'should skip bytes', ->
     cleverBuffer = new CleverBufferReader buf
-    cleverBuffer.skip 4
+    returnVal = cleverBuffer.skip 4
+    (typeof returnVal).should.eql('undefined') # Skipping shouldn't return a value
     cleverBuffer.getOffset().should.eql 4
 
   it 'should skip to set offset', ->


### PR DESCRIPTION
The return value of skip is currently the offset number.
It should be null or undefined, or explicitly returned if this is the intended behavior.

This change will BREAK TESTS on update in some dependent packages (keno-messages definitely) which explicitly test that the key marked as 'skip' has the value of the offset.