### PR TITLE
Update dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "test": "node_modules/.bin/mocha"
   },
   "dependencies": {
-    "coffee-script": "~1.7.1",
-    "lodash": "~2.4.1",
-    "ref": "~1.1.0"
+    "coffee-script": "~1.10.0",
+    "lodash": "~4.10.0",
+    "ref": "~1.3.2"
   },
   "devDependencies": {
-    "should": "~4.0.4",
-    "mocha": "~1.20.1"
+    "should": "~8.3.0",
+    "mocha": "~2.4.5"
   }
 }


### PR DESCRIPTION
Update all dev & runtime dependencies to latest
- tests still pass :)
- fixes vulnerability Snyk detected in `ref@0.1.3` (which depends on `"debug": "*"`, `ref@1.3.2` now has a pinned dependency)