### PR TITLE
Compile to JS before publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+target
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 .gitignore
 .npmignore
 .travis.yml
+src
 test

--- a/package.json
+++ b/package.json
@@ -11,17 +11,19 @@
   "bugs": {
     "url": "https://github.com/TabDigital/clever-buffer/issues"
   },
-  "main": "src/clever-buffer.js",
+  "main": "target/clever-buffer.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha"
+    "test": "node_modules/.bin/mocha",
+    "compile": "coffee --output target --compile src",
+    "prepublish": "npm test && npm run compile"
   },
   "dependencies": {
-    "coffee-script": "~1.10.0",
     "lodash": "~4.10.0",
     "ref": "~1.3.2"
   },
   "devDependencies": {
-    "should": "~8.3.0",
-    "mocha": "~2.4.5"
+    "coffee-script": "~1.10.0",
+    "mocha": "~2.4.5",
+    "should": "~8.3.0"
   }
 }

--- a/src/clever-buffer.coffee
+++ b/src/clever-buffer.coffee
@@ -1,0 +1,2 @@
+exports.CleverBufferReader = require("./clever-buffer-reader");
+exports.CleverBufferWriter = require("./clever-buffer-writer");

--- a/src/clever-buffer.js
+++ b/src/clever-buffer.js
@@ -1,4 +1,0 @@
-require("coffee-script/register");
-
-exports.CleverBufferReader = require("./clever-buffer-reader");
-exports.CleverBufferWriter = require("./clever-buffer-writer");


### PR DESCRIPTION
Only publish compiled JS code, which runs a little faster & also means faster install.
